### PR TITLE
Optimize UTF-16 string read

### DIFF
--- a/AquaModelLibrary.Data/PSO2/Aqua/ItemNameCacheIndex.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/ItemNameCacheIndex.cs
@@ -36,7 +36,7 @@ namespace AquaModelLibrary.Data.PSO2.Aqua
                 int strPointer = sr.Read<int>();
                 long bookmark = sr.Position;
                 sr.Seek(strPointer + offset, SeekOrigin.Begin);
-                output.AppendLine($"{category.ToString("X")} {id.ToString("X")} " + sr.ReadUTF16String());
+                output.AppendLine($"{category.ToString("X")} {id.ToString("X")} " + sr.ReadUTF16String(this.nifl.NOF0Offset));
 
                 sr.Seek(bookmark, SeekOrigin.Begin);
             }

--- a/AquaModelLibrary.Data/PSO2/Aqua/ItemNameCacheIndex.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/ItemNameCacheIndex.cs
@@ -102,7 +102,7 @@ namespace AquaModelLibrary.Data.PSO2.Aqua
                 }
                 for(int i = 0; i < entryCount; i++)
                 {
-                    entries[i].name = sr.ReadUTF16String();
+                    entries[i].name = sr.ReadUTF16String(0x1000);
                     sr.Seek((entries[i].name.Length + 1) * 2, SeekOrigin.Current);
                 }
             }

--- a/AquaModelLibrary.Data/PSO2/Aqua/ItemNameCacheIndex.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/ItemNameCacheIndex.cs
@@ -36,8 +36,10 @@ namespace AquaModelLibrary.Data.PSO2.Aqua
                 int strPointer = sr.Read<int>();
                 long bookmark = sr.Position;
                 sr.Seek(strPointer + offset, SeekOrigin.Begin);
-                output.AppendLine($"{category.ToString("X")} {id.ToString("X")} " + sr.ReadUTF16String(this.nifl.NOF0Offset));
-
+                if(sr.Position < this.nifl.NOF0Offset)
+                {
+                    output.AppendLine($"{category.ToString("X")} {id.ToString("X")} " + sr.ReadUTF16String(this.nifl.NOF0Offset - sr.Position));
+                }
                 sr.Seek(bookmark, SeekOrigin.Begin);
             }
         }

--- a/AquaModelLibrary.Data/PSO2/Aqua/ItemNameCacheIndex.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/ItemNameCacheIndex.cs
@@ -36,7 +36,7 @@ namespace AquaModelLibrary.Data.PSO2.Aqua
                 int strPointer = sr.Read<int>();
                 long bookmark = sr.Position;
                 sr.Seek(strPointer + offset, SeekOrigin.Begin);
-                output.AppendLine($"{category.ToString("X")} {id.ToString("X")} " + sr.ReadUTF16String(true, (int)sr.BaseStream.Length));
+                output.AppendLine($"{category.ToString("X")} {id.ToString("X")} " + sr.ReadUTF16String());
 
                 sr.Seek(bookmark, SeekOrigin.Begin);
             }

--- a/AquaModelLibrary.Data/PSO2/Aqua/PSO2Text.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/PSO2Text.cs
@@ -148,7 +148,7 @@ namespace AquaModelLibrary.Data.PSO2.Aqua
                         pair.name = sr.ReadCString();
 
                         sr.Seek(textLoc + offset, SeekOrigin.Begin);
-                        pair.str = sr.ReadUTF16String();
+                        pair.str = sr.ReadUTF16String(this.nifl.NOF0Offset);
 
                         text[i][subCategoryId].Add(pair);
                         sr.Seek(bookmarkLocal, SeekOrigin.Begin);

--- a/AquaModelLibrary.Data/PSO2/Aqua/PSO2Text.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/PSO2Text.cs
@@ -148,7 +148,10 @@ namespace AquaModelLibrary.Data.PSO2.Aqua
                         pair.name = sr.ReadCString();
 
                         sr.Seek(textLoc + offset, SeekOrigin.Begin);
-                        pair.str = sr.ReadUTF16String(this.nifl.NOF0Offset);
+                        if(sr.Position < this.nifl.NOF0Offset)
+                        {
+                            pair.str = sr.ReadUTF16String(this.nifl.NOF0Offset - sr.Position);
+                        }
 
                         text[i][subCategoryId].Add(pair);
                         sr.Seek(bookmarkLocal, SeekOrigin.Begin);

--- a/AquaModelLibrary.Data/PSO2/Aqua/PSO2Text.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/PSO2Text.cs
@@ -148,7 +148,7 @@ namespace AquaModelLibrary.Data.PSO2.Aqua
                         pair.name = sr.ReadCString();
 
                         sr.Seek(textLoc + offset, SeekOrigin.Begin);
-                        pair.str = sr.ReadUTF16String(true, (int)sr.BaseStream.Length);
+                        pair.str = sr.ReadUTF16String();
 
                         text[i][subCategoryId].Add(pair);
                         sr.Seek(bookmarkLocal, SeekOrigin.Begin);


### PR DESCRIPTION
Optimized ReadUTF16String() using code based on the example at https://learn.microsoft.com/en-us/dotnet/api/system.text.decoder.convert?view=net-8.0. This reduces the time to run ReferenceGenerator.ReadCMXText() from 48 seconds to under 1 second on my PC.

A similar change could probably be made to improve the other string read functions, but ReadUTF16String() was the only one I saw getting used a significant amount when reading CMX data, so I didn't change the others.