### PR TITLE
Fix slow UTF-16 string reads

### DIFF
--- a/AquaModelLibrary.Data/PSO2/Aqua/PSO2Text.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/PSO2Text.cs
@@ -150,7 +150,7 @@ namespace AquaModelLibrary.Data.PSO2.Aqua
                         sr.Seek(textLoc + offset, SeekOrigin.Begin);
                         if(sr.Position < this.nifl.NOF0Offset)
                         {
-                            pair.str = sr.ReadUTF16String(sr.Position, (int)(this.nifl.NOF0Offset - sr.Position));
+                            pair.str = sr.ReadUTF16String(sr.Position);
                         }
 
                         text[i][subCategoryId].Add(pair);

--- a/AquaModelLibrary.Helpers/Readers/BufferedStreamReaderBE.cs
+++ b/AquaModelLibrary.Helpers/Readers/BufferedStreamReaderBE.cs
@@ -491,7 +491,7 @@ namespace AquaModelLibrary.Helpers.Readers
                     }
 
                     decoder.Convert(source.AsBytes(), dest, foundEnd, out var bytesUsed, out var charsUsed, out var completed);
-                    sb.Append(new string(dest, 0, charsUsed));
+                    sb.Append(dest.AsSpan()[0..charsUsed]);
                 } while (!foundEnd);
             }
             return sb.ToString();


### PR DESCRIPTION
ReferenceGenerator.ReadCMXText() was taking longer than expected, and Visual Studio's profiler was showing the "new char[blockSize / 2]" line of ReadUTF16String() to be taking the majority of the time. This was caused by PSO2Text asking to read the entire remaining data in the file every time it needed to read a string. Letting it use the default read size and just keep doing more reads if it didn't find the end of the string is significantly faster.

Also improved ReadUTF16String() to replace an intermediate string allocation with a span.

Together, these reduce ReferenceGenerator.ReadCMXText() from 8-10 seconds to about 0.7 seconds on my machine.