### PR TITLE
Add mask color mappings for BBLY, HAIR, and NGS_Ear

### DIFF
--- a/AquaModelLibrary.Data/PSO2/Aqua/CharacterMakingIndexData/BBLY.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/CharacterMakingIndexData/BBLY.cs
@@ -60,8 +60,7 @@ namespace AquaModelLibrary.Data.PSO2.Aqua.CharacterMakingIndexData
 
         public int texString4Ptr;
         public int texString5Ptr;
-        public int unkInt0;       //This value forward may just be junk or new functionality in this version. Old BBLY only had the id and texture strings. Seems to correlate to BODY stuff though.
-        public int unkInt1;
+        public BBLYMaskColorMapping maskColorMapping; //This value forward may just be junk or new functionality in this version. Old BBLY only had the id and texture strings. Seems to correlate to BODY stuff though.
 
         public int unkInt2;
         public int unkInt3;
@@ -75,5 +74,11 @@ namespace AquaModelLibrary.Data.PSO2.Aqua.CharacterMakingIndexData
 
         public float unkFloat4;
         public float unkFloat5;
+    }
+
+    public struct BBLYMaskColorMapping
+    {
+        public CharColorMapping redIndex;
+        public CharColorMapping greenIndex;
     }
 }

--- a/AquaModelLibrary.Data/PSO2/Aqua/CharacterMakingIndexData/CharColorMapping.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/CharacterMakingIndexData/CharColorMapping.cs
@@ -3,6 +3,7 @@
     //Credit to dummyCount and Dillen for these values
     public enum CharColorMapping : int
     {
+        None = 0,
         PrimaryOuterWear = 1,
         SecondaryOuterWear = 2,
         PrimaryBaseWear = 3,
@@ -19,6 +20,7 @@
         LeftEye = 14,
         EyebrowColor = 15,
         EyelashColor = 16,
-        HairColor = 17,
+        HairColor1 = 17,
+        HairColor2 = 18,
     }
 }

--- a/AquaModelLibrary.Data/PSO2/Aqua/CharacterMakingIndexData/HAIR.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/CharacterMakingIndexData/HAIR.cs
@@ -78,9 +78,8 @@ namespace AquaModelLibrary.Data.PSO2.Aqua.CharacterMakingIndexData
         public float unkFloat8;
         public float unkFloat9;
         public int unkInt15;
-        public int unkInt16;
+        public HAIRMaskColorMapping maskColorMapping; //Color mappings for NGS hairs. Always seems to be 0x64 followed by 0s for classic hairs.
 
-        public int unkInt17;
         public int unkInt18;
         public int unkInt19;
         public int unkInt20;
@@ -89,5 +88,18 @@ namespace AquaModelLibrary.Data.PSO2.Aqua.CharacterMakingIndexData
         public short unkShortB2; //0xB2, 0x6
         public short unkShortB3; //0xB3, 0x6
         public short unkShort0;
+    }
+
+    public struct HAIRMaskColorMapping
+    {
+        public short redIndex;
+        public short greenIndex;
+        public short blueIndex;
+        public short alphaIndex;
+
+        public readonly CharColorMapping RedIndex => (CharColorMapping)redIndex;
+        public readonly CharColorMapping GreenIndex => (CharColorMapping)greenIndex;
+        public readonly CharColorMapping BlueIndex => (CharColorMapping)blueIndex;
+        public readonly CharColorMapping AlphaIndex => (CharColorMapping)alphaIndex;
     }
 }

--- a/AquaModelLibrary.Data/PSO2/Aqua/CharacterMakingIndexData/NGS_Ear.cs
+++ b/AquaModelLibrary.Data/PSO2/Aqua/CharacterMakingIndexData/NGS_Ear.cs
@@ -25,9 +25,14 @@
         public int texString5Ptr;
         public int unkInt0;
 
-        public int unkInt1;
-        public int unkInt2;
-        public int unkInt3;
-        public int unkInt4;
+        public NGS_EarColorMapping maskColorMapping;
+    }
+
+    public struct NGS_EarColorMapping
+    {
+        public CharColorMapping redIndex;
+        public CharColorMapping greenIndex;
+        public CharColorMapping blueIndex;
+        public CharColorMapping alphaIndex;
     }
 }


### PR DESCRIPTION
For BBLY objects, the first two unknown ints are color mappings for the red and green channels. The following two could be the blue and alpha channels, but those aren't used by anything I've checked, so I can't confirm that.

For NGS ear objects, unknown ints 1-4 are color mappings.

For NGS hair objects, unknown ints 16-17 are the four colors mapping values with each one packed into 2 bytes instead of 4. For classic hairs, these are something else, but it's always 0x64 followed by 0s, so might just be garbage that's not used.

Added CharColorMapping enum values for the second hair color and for a channel being unused.