### PR TITLE
Assimp fixes

### DIFF
--- a/AquaModelLibrary.Core/AquaModelLibrary.Core.csproj
+++ b/AquaModelLibrary.Core/AquaModelLibrary.Core.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AssimpNet" Version="5.0.0-beta1" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="Reloaded.Memory" Version="9.4.2" />
+    <PackageReference Include="SharpAssimp" Version="6.0.11" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.11" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/AquaModelLibrary.Core/General/AssimpModelExporter.cs
+++ b/AquaModelLibrary.Core/General/AssimpModelExporter.cs
@@ -278,39 +278,44 @@ namespace AquaModelLibrary.Core.General
                     //Iterate through vertices
                     for (int vertId = 0; vertId < vtxl.vertWeightIndices.Count; vertId++)
                     {
-                        var boneIndices = vtxl.vertWeightIndices[vertId];
+                        var weightIndices = vtxl.vertWeightIndices[vertId];
                         var boneWeights = Vector4ToFloatArray(vtxl.vertWeights[vertId]);
 
                         //Iterate through weights
                         for (int wt = 0; wt < 4; wt++)
                         {
-                            var boneIndex = boneIndices[wt];
+                            var weightIndex = weightIndices[wt];
                             var boneWeight = boneWeights[wt];
 
                             if (boneWeight == 0.0f)
                                 continue;
 
-                            if (!aiBoneMap.Keys.Contains(boneIndex))
+                            var boneIndex = (int)bonePalette[weightIndex];
+                            if (boneIndex >= aqn.nodeList.Count)
                             {
-                                var aiBone = new SharpAssimp.Bone();
-                                var aqnBone = boneArray[bonePalette[boneIndex]];
-                                var rawBone = aqn.nodeList[(int)bonePalette[boneIndex]];
+                                boneIndex = 0;
+                            }
 
-                                aiBone.Name = $"({bonePalette[boneIndex]})" + rawBone.boneName.GetString();
+                            if (!aiBoneMap.TryGetValue(boneIndex, out var aiBone))
+                            {
+                                aiBone = new SharpAssimp.Bone();
+                                var aqnBone = boneArray[boneIndex];
+                                var rawBone = aqn.nodeList[boneIndex];
+
+                                aiBone.Name = $"({boneIndex})" + rawBone.boneName.GetString();
                                 aiBone.VertexWeights.Add(new SharpAssimp.VertexWeight(vertId, boneWeight));
 
                                 var invTransform = new Matrix4x4(rawBone.m1.X, rawBone.m2.X, rawBone.m3.X, rawBone.m4.X,
-                                                                     rawBone.m1.Y, rawBone.m2.Y, rawBone.m3.Y, rawBone.m4.Y,
-                                                                     rawBone.m1.Z, rawBone.m2.Z, rawBone.m3.Z, rawBone.m4.Z,
-                                                                     rawBone.m1.W, rawBone.m2.W, rawBone.m3.W, rawBone.m4.W);
+                                                                 rawBone.m1.Y, rawBone.m2.Y, rawBone.m3.Y, rawBone.m4.Y,
+                                                                 rawBone.m1.Z, rawBone.m2.Z, rawBone.m3.Z, rawBone.m4.Z,
+                                                                 rawBone.m1.W, rawBone.m2.W, rawBone.m3.W, rawBone.m4.W);
 
                                 aiBone.OffsetMatrix = invTransform;
-
                                 aiBoneMap[boneIndex] = aiBone;
                             }
 
-                            if (!aiBoneMap[boneIndex].VertexWeights.Any(x => x.VertexID == vertId))
-                                aiBoneMap[boneIndex].VertexWeights.Add(new SharpAssimp.VertexWeight(vertId, boneWeight));
+                            if (!aiBone.VertexWeights.Any(x => x.VertexID == vertId))
+                                aiBone.VertexWeights.Add(new SharpAssimp.VertexWeight(vertId, boneWeight));
                         }
                     }
 

--- a/AquaModelLibrary.Core/General/AssimpModelExporter.cs
+++ b/AquaModelLibrary.Core/General/AssimpModelExporter.cs
@@ -7,7 +7,7 @@ namespace AquaModelLibrary.Core.General
 {
     public static class AssimpModelExporter
     {
-        public static Assimp.Scene AssimpExport(string filePath, AquaObject aqp, AquaNode aqn)
+        public static SharpAssimp.Scene AssimpExport(string filePath, AquaObject aqp, AquaNode aqn)
         {
             if (aqp.IsNGS)
             {
@@ -16,16 +16,16 @@ namespace AquaModelLibrary.Core.General
                 aqp = aqp.Clone();
                 aqp.splitVSETPerMesh();
             }
-            Assimp.Scene aiScene = new Assimp.Scene();
+            SharpAssimp.Scene aiScene = new SharpAssimp.Scene();
 
             //Create an array to hold references to these since Assimp lacks a way to grab these by order or id
             //We don't need the nodo count in this since they can't be parents
-            Assimp.Node[] boneArray = new Assimp.Node[aqn.nodeList.Count];
+            SharpAssimp.Node[] boneArray = new SharpAssimp.Node[aqn.nodeList.Count];
 
             //Set up root node
             var root = aqn.nodeList[0];
-            var aiRootNode = new Assimp.Node("RootNode", null);
-            aiRootNode.Transform = Assimp.Matrix4x4.Identity;
+            var aiRootNode = new SharpAssimp.Node("RootNode", null);
+            aiRootNode.Transform = Matrix4x4.Identity;
 
             aiScene.RootNode = aiRootNode;
 
@@ -33,7 +33,7 @@ namespace AquaModelLibrary.Core.General
             for (int i = 0; i < aqn.nodeList.Count; i++)
             {
                 var bn = aqn.nodeList[i];
-                Assimp.Node parentNode;
+                SharpAssimp.Node parentNode;
                 var parentTfm = Matrix4x4.Identity;
                 if (bn.parentId == -1)
                 {
@@ -48,7 +48,7 @@ namespace AquaModelLibrary.Core.General
                                                 pn.m3.X, pn.m3.Y, pn.m3.Z, pn.m3.W,
                                                 pn.m4.X, pn.m4.Y, pn.m4.Z, pn.m4.W);
                 }
-                var aiNode = new Assimp.Node($"({i})" + bn.boneName.GetString(), parentNode);
+                var aiNode = new SharpAssimp.Node($"({i})" + bn.boneName.GetString(), parentNode);
 
                 //Use inverse bind matrix as base
                 var bnMat = new Matrix4x4(bn.m1.X, bn.m1.Y, bn.m1.Z, bn.m1.W,
@@ -58,7 +58,7 @@ namespace AquaModelLibrary.Core.General
                 Matrix4x4.Invert(bnMat, out bnMat);
 
                 //Get local transform
-                aiNode.Transform = GetAssimpMat4(bnMat * parentTfm);
+                aiNode.Transform = bnMat * parentTfm;
 
                 parentNode.Children.Add(aiNode);
                 boneArray[i] = aiNode;
@@ -67,16 +67,16 @@ namespace AquaModelLibrary.Core.General
             foreach (NODO bn in aqn.nodoList)
             {
                 var parentNodo = boneArray[bn.parentId];
-                var aiNode = new Assimp.Node(bn.boneName.GetString(), parentNodo);
+                var aiNode = new SharpAssimp.Node(bn.boneName.GetString(), parentNodo);
 
                 //NODOs are a bit more primitive. We need to generate the matrix for these ones.
-                var matrix = Assimp.Matrix4x4.Identity;
-                var rotation = Assimp.Matrix4x4.FromRotationX(bn.eulRot.X) *
-                   Assimp.Matrix4x4.FromRotationY(bn.eulRot.Y) *
-                   Assimp.Matrix4x4.FromRotationZ(bn.eulRot.Z);
+                var matrix = Matrix4x4.Identity;
+                var rotation = MatrixFromRotationX(bn.eulRot.X) *
+                   MatrixFromRotationY(bn.eulRot.Y) *
+                   MatrixFromRotationZ(bn.eulRot.Z);
 
                 matrix *= rotation;
-                matrix *= Assimp.Matrix4x4.FromTranslation(new Assimp.Vector3D(bn.pos.X, bn.pos.Y, bn.pos.Z));
+                matrix *= MatrixFromTranslation(new Vector3(bn.pos.X, bn.pos.Y, bn.pos.Z));
                 aiNode.Transform = matrix;
 
                 parentNodo.Children.Add(aiNode);
@@ -92,7 +92,7 @@ namespace AquaModelLibrary.Core.General
                 var aiMeshName = string.Format("mesh[{4}]_{0}_{1}_{2}_{3}_mesh", msh.mateIndex, msh.rendIndex, msh.shadIndex, msh.tsetIndex, aiScene.Meshes.Count);
                 bool hasVertexWeights = aqp.vtxlList[msh.vsetIndex].vertWeightIndices.Count > 0;
 
-                var aiMesh = new Assimp.Mesh(aiMeshName, Assimp.PrimitiveType.Triangle);
+                var aiMesh = new SharpAssimp.Mesh(aiMeshName, SharpAssimp.PrimitiveType.Triangle);
 
                 if (hasVertexWeights)
                 {
@@ -119,20 +119,20 @@ namespace AquaModelLibrary.Core.General
                     if (vtxl.vertPositions.Count > 0)
                     {
                         var pos = vtxl.vertPositions[vertId];
-                        aiMesh.Vertices.Add(new Assimp.Vector3D(pos.X, pos.Y, pos.Z));
+                        aiMesh.Vertices.Add(new Vector3(pos.X, pos.Y, pos.Z));
                     }
 
                     if (vtxl.vertNormals.Count > 0)
                     {
                         var nrm = vtxl.vertNormals[vertId];
-                        aiMesh.Normals.Add(new Assimp.Vector3D(nrm.X, nrm.Y, nrm.Z));
+                        aiMesh.Normals.Add(new Vector3(nrm.X, nrm.Y, nrm.Z));
                     }
 
                     if (vtxl.vertColors.Count > 0)
                     {
                         //Vert colors are bgra
                         var rawClr = vtxl.vertColors[vertId];
-                        var clr = new Assimp.Color4D(clrToFloat(rawClr[2]), clrToFloat(rawClr[1]), clrToFloat(rawClr[0]), clrToFloat(rawClr[3]));
+                        var clr = new Vector4(clrToFloat(rawClr[2]), clrToFloat(rawClr[1]), clrToFloat(rawClr[0]), clrToFloat(rawClr[3]));
                         aiMesh.VertexColorChannels[0].Add(clr);
                     }
 
@@ -140,127 +140,127 @@ namespace AquaModelLibrary.Core.General
                     {
                         //Vert colors are bgra
                         var rawClr = vtxl.vertColor2s[vertId];
-                        var clr = new Assimp.Color4D(clrToFloat(rawClr[2]), clrToFloat(rawClr[1]), clrToFloat(rawClr[0]), clrToFloat(rawClr[3]));
+                        var clr = new Vector4(clrToFloat(rawClr[2]), clrToFloat(rawClr[1]), clrToFloat(rawClr[0]), clrToFloat(rawClr[3]));
                         aiMesh.VertexColorChannels[1].Add(clr);
                     }
 
                     if (vtxl.uv1List.Count > 0)
                     {
                         var textureCoordinate = vtxl.uv1List[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(textureCoordinate.X, textureCoordinate.Y, 0f);
+                        var aiTextureCoordinate = new Vector3(textureCoordinate.X, textureCoordinate.Y, 0f);
                         aiMesh.TextureCoordinateChannels[0].Add(aiTextureCoordinate);
                     }
                     else
                     {
-                        var aiTextureCoordinate = new Assimp.Vector3D(1, 1, 1);
+                        var aiTextureCoordinate = new Vector3(1, 1, 1);
                         aiMesh.TextureCoordinateChannels[0].Add(aiTextureCoordinate);
                     }
 
                     if (vtxl.uv2List.Count > 0)
                     {
                         var textureCoordinate = vtxl.uv2List[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(textureCoordinate.X, textureCoordinate.Y, 0f);
+                        var aiTextureCoordinate = new Vector3(textureCoordinate.X, textureCoordinate.Y, 0f);
                         aiMesh.TextureCoordinateChannels[1].Add(aiTextureCoordinate);
                     }
                     else
                     {
-                        var aiTextureCoordinate = new Assimp.Vector3D(1, 1, 1);
+                        var aiTextureCoordinate = new Vector3(1, 1, 1);
                         aiMesh.TextureCoordinateChannels[1].Add(aiTextureCoordinate);
                     }
 
                     if (vtxl.uv3List.Count > 0)
                     {
                         var textureCoordinate = vtxl.uv3List[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(textureCoordinate.X, textureCoordinate.Y, 0f);
+                        var aiTextureCoordinate = new Vector3(textureCoordinate.X, textureCoordinate.Y, 0f);
                         aiMesh.TextureCoordinateChannels[2].Add(aiTextureCoordinate);
                     }
                     else
                     {
-                        var aiTextureCoordinate = new Assimp.Vector3D(1, 1, 1);
+                        var aiTextureCoordinate = new Vector3(1, 1, 1);
                         aiMesh.TextureCoordinateChannels[2].Add(aiTextureCoordinate);
                     }
 
                     if (vtxl.uv4List.Count > 0)
                     {
                         var textureCoordinate = vtxl.uv4List[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(textureCoordinate.X, textureCoordinate.Y, 0f);
+                        var aiTextureCoordinate = new Vector3(textureCoordinate.X, textureCoordinate.Y, 0f);
                         aiMesh.TextureCoordinateChannels[3].Add(aiTextureCoordinate);
                     }
                     else
                     {
-                        var aiTextureCoordinate = new Assimp.Vector3D(1, 1, 1);
+                        var aiTextureCoordinate = new Vector3(1, 1, 1);
                         aiMesh.TextureCoordinateChannels[3].Add(aiTextureCoordinate);
                     }
 
                     if (vtxl.vert0x22.Count > 0)
                     {
                         var textureCoordinate = vtxl.vert0x22[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(uvShortToFloat(textureCoordinate[0]), uvShortToFloat(textureCoordinate[1]), 0f);
+                        var aiTextureCoordinate = new Vector3(uvShortToFloat(textureCoordinate[0]), uvShortToFloat(textureCoordinate[1]), 0f);
                         aiMesh.TextureCoordinateChannels[4].Add(aiTextureCoordinate);
                     }
                     else if (vtxl.uv5List.Count > 0)
                     {
                         var textureCoordinate = vtxl.uv5List[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(textureCoordinate.X, textureCoordinate.Y, 0f);
+                        var aiTextureCoordinate = new Vector3(textureCoordinate.X, textureCoordinate.Y, 0f);
                         aiMesh.TextureCoordinateChannels[4].Add(aiTextureCoordinate);
                     }
                     else
                     {
-                        var aiTextureCoordinate = new Assimp.Vector3D(1, 1, 1);
+                        var aiTextureCoordinate = new Vector3(1, 1, 1);
                         aiMesh.TextureCoordinateChannels[4].Add(aiTextureCoordinate);
                     }
 
                     if (vtxl.vert0x23.Count > 0)
                     {
                         var textureCoordinate = vtxl.vert0x23[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(uvShortToFloat(textureCoordinate[0]), uvShortToFloat(textureCoordinate[1]), 0f);
+                        var aiTextureCoordinate = new Vector3(uvShortToFloat(textureCoordinate[0]), uvShortToFloat(textureCoordinate[1]), 0f);
                         aiMesh.TextureCoordinateChannels[5].Add(aiTextureCoordinate);
                     }
                     else if (vtxl.uv6List.Count > 0)
                     {
                         var textureCoordinate = vtxl.uv6List[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(textureCoordinate.X, textureCoordinate.Y, 0f);
+                        var aiTextureCoordinate = new Vector3(textureCoordinate.X, textureCoordinate.Y, 0f);
                         aiMesh.TextureCoordinateChannels[5].Add(aiTextureCoordinate);
                     }
                     else
                     {
-                        var aiTextureCoordinate = new Assimp.Vector3D(1, 1, 1);
+                        var aiTextureCoordinate = new Vector3(1, 1, 1);
                         aiMesh.TextureCoordinateChannels[5].Add(aiTextureCoordinate);
                     }
 
                     if (vtxl.vert0x24.Count > 0)
                     {
                         var textureCoordinate = vtxl.vert0x24[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(uvShortToFloat(textureCoordinate[0]), uvShortToFloat(textureCoordinate[1]), 0f);
+                        var aiTextureCoordinate = new Vector3(uvShortToFloat(textureCoordinate[0]), uvShortToFloat(textureCoordinate[1]), 0f);
                         aiMesh.TextureCoordinateChannels[6].Add(aiTextureCoordinate);
                     }
                     else if (vtxl.uv7List.Count > 0)
                     {
                         var textureCoordinate = vtxl.uv7List[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(textureCoordinate.X, textureCoordinate.Y, 0f);
+                        var aiTextureCoordinate = new Vector3(textureCoordinate.X, textureCoordinate.Y, 0f);
                         aiMesh.TextureCoordinateChannels[6].Add(aiTextureCoordinate);
                     }
                     else
                     {
-                        var aiTextureCoordinate = new Assimp.Vector3D(1, 1, 1);
+                        var aiTextureCoordinate = new Vector3(1, 1, 1);
                         aiMesh.TextureCoordinateChannels[6].Add(aiTextureCoordinate);
                     }
 
                     if (vtxl.vert0x25.Count > 0)
                     {
                         var textureCoordinate = vtxl.vert0x25[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(uvShortToFloat(textureCoordinate[0]), uvShortToFloat(textureCoordinate[1]), 0f);
+                        var aiTextureCoordinate = new Vector3(uvShortToFloat(textureCoordinate[0]), uvShortToFloat(textureCoordinate[1]), 0f);
                         aiMesh.TextureCoordinateChannels[7].Add(aiTextureCoordinate);
                     }
                     else if (vtxl.uv8List.Count > 0)
                     {
                         var textureCoordinate = vtxl.uv8List[vertId];
-                        var aiTextureCoordinate = new Assimp.Vector3D(textureCoordinate.X, textureCoordinate.Y, 0f);
+                        var aiTextureCoordinate = new Vector3(textureCoordinate.X, textureCoordinate.Y, 0f);
                         aiMesh.TextureCoordinateChannels[7].Add(aiTextureCoordinate);
                     }
                     else
                     {
-                        var aiTextureCoordinate = new Assimp.Vector3D(1, 1, 1);
+                        var aiTextureCoordinate = new Vector3(1, 1, 1);
                         aiMesh.TextureCoordinateChannels[7].Add(aiTextureCoordinate);
                     }
                 }
@@ -273,7 +273,7 @@ namespace AquaModelLibrary.Core.General
                 //Assimp Bones - Assimp likes to store vertex weights in bones and bones references in meshes
                 if (hasVertexWeights)
                 {
-                    var aiBoneMap = new Dictionary<int, Assimp.Bone>();
+                    var aiBoneMap = new Dictionary<int, SharpAssimp.Bone>();
 
                     //Iterate through vertices
                     for (int vertId = 0; vertId < vtxl.vertWeightIndices.Count; vertId++)
@@ -292,14 +292,14 @@ namespace AquaModelLibrary.Core.General
 
                             if (!aiBoneMap.Keys.Contains(boneIndex))
                             {
-                                var aiBone = new Assimp.Bone();
+                                var aiBone = new SharpAssimp.Bone();
                                 var aqnBone = boneArray[bonePalette[boneIndex]];
                                 var rawBone = aqn.nodeList[(int)bonePalette[boneIndex]];
 
                                 aiBone.Name = $"({bonePalette[boneIndex]})" + rawBone.boneName.GetString();
-                                aiBone.VertexWeights.Add(new Assimp.VertexWeight(vertId, boneWeight));
+                                aiBone.VertexWeights.Add(new SharpAssimp.VertexWeight(vertId, boneWeight));
 
-                                var invTransform = new Assimp.Matrix4x4(rawBone.m1.X, rawBone.m2.X, rawBone.m3.X, rawBone.m4.X,
+                                var invTransform = new Matrix4x4(rawBone.m1.X, rawBone.m2.X, rawBone.m3.X, rawBone.m4.X,
                                                                      rawBone.m1.Y, rawBone.m2.Y, rawBone.m3.Y, rawBone.m4.Y,
                                                                      rawBone.m1.Z, rawBone.m2.Z, rawBone.m3.Z, rawBone.m4.Z,
                                                                      rawBone.m1.W, rawBone.m2.W, rawBone.m3.W, rawBone.m4.W);
@@ -310,7 +310,7 @@ namespace AquaModelLibrary.Core.General
                             }
 
                             if (!aiBoneMap[boneIndex].VertexWeights.Any(x => x.VertexID == vertId))
-                                aiBoneMap[boneIndex].VertexWeights.Add(new Assimp.VertexWeight(vertId, boneWeight));
+                                aiBoneMap[boneIndex].VertexWeights.Add(new SharpAssimp.VertexWeight(vertId, boneWeight));
                         }
                     }
 
@@ -319,7 +319,7 @@ namespace AquaModelLibrary.Core.General
                 }
                 else //Handle rigid meshes
                 {
-                    var aiBone = new Assimp.Bone();
+                    var aiBone = new SharpAssimp.Bone();
                     var aqnBone = boneArray[msh.baseMeshNodeId];
 
                     // Name
@@ -328,11 +328,11 @@ namespace AquaModelLibrary.Core.General
                     // VertexWeights
                     for (int i = 0; i < aiMesh.Vertices.Count; i++)
                     {
-                        var aiVertexWeight = new Assimp.VertexWeight(i, 1f);
+                        var aiVertexWeight = new SharpAssimp.VertexWeight(i, 1f);
                         aiBone.VertexWeights.Add(aiVertexWeight);
                     }
 
-                    aiBone.OffsetMatrix = Assimp.Matrix4x4.Identity;
+                    aiBone.OffsetMatrix = Matrix4x4.Identity;
 
                     aiMesh.Bones.Add(aiBone);
                 }
@@ -340,19 +340,19 @@ namespace AquaModelLibrary.Core.General
                 //Faces
                 foreach (var face in aqp.strips[msh.vsetIndex].GetTriangles(true))
                 {
-                    aiMesh.Faces.Add(new Assimp.Face(new int[] { (int)face.X, (int)face.Y, (int)face.Z }));
+                    aiMesh.Faces.Add(new SharpAssimp.Face(new int[] { (int)face.X, (int)face.Y, (int)face.Z }));
                 }
 
                 //Material
                 var mat = aqp.mateList[msh.mateIndex];
                 var shaderSet = aqp.GetShaderNames(msh.shadIndex);
                 var textureSet = aqp.GetTexListNamesUnicode(msh.tsetIndex);
-                Assimp.Material mate = new Assimp.Material();
+                SharpAssimp.Material mate = new SharpAssimp.Material();
 
-                mate.ColorDiffuse = new Assimp.Color4D(mat.diffuseRGBA.X, mat.diffuseRGBA.Y, mat.diffuseRGBA.Z, mat.diffuseRGBA.W);
+                mate.ColorDiffuse = new Vector4(mat.diffuseRGBA.X, mat.diffuseRGBA.Y, mat.diffuseRGBA.Z, mat.diffuseRGBA.W);
                 if (mat.alphaType.GetString().Equals("add"))
                 {
-                    mate.BlendMode = Assimp.BlendMode.Additive;
+                    mate.BlendMode = SharpAssimp.BlendMode.Additive;
                 }
                 mate.Name = "(" + shaderSet[0] + "," + shaderSet[1] + ")" + "{" + mat.alphaType.GetString() + "}" + mat.matName.GetString();
 
@@ -362,61 +362,61 @@ namespace AquaModelLibrary.Core.General
                     switch (i)
                     {
                         case 0:
-                            mate.TextureDiffuse = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Diffuse, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureDiffuse = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Diffuse, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         case 1:
-                            mate.TextureSpecular = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Specular, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureSpecular = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Specular, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         case 2:
-                            mate.TextureNormal = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Normals, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureNormal = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Normals, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         case 3:
-                            mate.TextureLightMap = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Lightmap, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureLightMap = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Lightmap, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         case 4:
-                            mate.TextureDisplacement = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Displacement, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureDisplacement = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Displacement, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         case 5:
-                            mate.TextureOpacity = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Opacity, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureOpacity = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Opacity, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         case 6:
-                            mate.TextureHeight = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Height, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureHeight = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Height, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         case 7:
-                            mate.TextureEmissive = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Emissive, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureEmissive = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Emissive, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         case 8:
-                            mate.TextureAmbient = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Ambient, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureAmbient = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Ambient, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         case 9:
-                            mate.TextureReflection = new Assimp.TextureSlot(
-                                textureSet[i], Assimp.TextureType.Reflection, i, Assimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
-                                Assimp.TextureOperation.Add, Assimp.TextureWrapMode.Wrap, Assimp.TextureWrapMode.Wrap, 0);
+                            mate.TextureReflection = new SharpAssimp.TextureSlot(
+                                textureSet[i], SharpAssimp.TextureType.Reflection, 0, SharpAssimp.TextureMapping.FromUV, aqp.tstaList[aqp.tsetList[msh.tsetIndex].tstaTexIDs[i]].modelUVSet, 0,
+                                SharpAssimp.TextureOperation.Add, SharpAssimp.TextureWrapMode.Wrap, SharpAssimp.TextureWrapMode.Wrap, 0);
                             break;
                         default:
                             break;
                     }
                 }
 
-                mate.ShadingMode = Assimp.ShadingMode.Phong;
+                mate.ShadingMode = SharpAssimp.ShadingMode.Phong;
 
 
                 var meshNodeName = string.Format("mesh[{4}]_{0}_{1}_{2}_{3}#{4}#{5}", msh.mateIndex, msh.rendIndex, msh.shadIndex, msh.tsetIndex, aiScene.Meshes.Count, msh.baseMeshNodeId, msh.baseMeshDummyId);
@@ -431,8 +431,8 @@ namespace AquaModelLibrary.Core.General
                 aiMesh.MaterialIndex = aiScene.Materials.Count - 1;
 
                 // Set up mesh node and add this mesh's index to it (This tells assimp to export it as a mesh for various formats)
-                var meshNode = new Assimp.Node(meshNodeName, aiScene.RootNode);
-                meshNode.Transform = Assimp.Matrix4x4.Identity;
+                var meshNode = new SharpAssimp.Node(meshNodeName, aiScene.RootNode);
+                meshNode.Transform = Matrix4x4.Identity;
 
                 aiScene.RootNode.Children.Add(meshNode);
 
@@ -442,23 +442,23 @@ namespace AquaModelLibrary.Core.General
             return aiScene;
         }
 
-        public static Assimp.Scene AssimpPRMExport(string filePath, PRM prm)
+        public static SharpAssimp.Scene AssimpPRMExport(string filePath, PRM prm)
         {
-            Assimp.Scene aiScene = new Assimp.Scene();
+            SharpAssimp.Scene aiScene = new SharpAssimp.Scene();
 
             //Create an array to hold references to these since Assimp lacks a way to grab these by order or id
             //We don't need the nodo count in this since they can't be parents
-            Assimp.Node[] boneArray = new Assimp.Node[2];
+            SharpAssimp.Node[] boneArray = new SharpAssimp.Node[2];
 
             //Set up root node
-            var aiRootNode = new Assimp.Node("RootNode", null);
-            aiRootNode.Transform = Assimp.Matrix4x4.Identity;
+            var aiRootNode = new SharpAssimp.Node("RootNode", null);
+            aiRootNode.Transform = Matrix4x4.Identity;
 
             boneArray[0] = aiRootNode;
             aiScene.RootNode = aiRootNode;
 
             //Set up single child node
-            var aiNode = new Assimp.Node(Path.GetFileNameWithoutExtension(filePath) + "_node", aiRootNode);
+            var aiNode = new SharpAssimp.Node(Path.GetFileNameWithoutExtension(filePath) + "_node", aiRootNode);
 
             //Use inverse bind matrix as base
 
@@ -471,7 +471,7 @@ namespace AquaModelLibrary.Core.General
             //Mesh
             string aiMeshName = Path.GetFileNameWithoutExtension(filePath);
 
-            var aiMesh = new Assimp.Mesh(aiMeshName, Assimp.PrimitiveType.Triangle);
+            var aiMesh = new SharpAssimp.Mesh(aiMeshName, SharpAssimp.PrimitiveType.Triangle);
 
             //Vertex face data - PSO2 Actually doesn't do this, it just has per vertex data so we can just map a vertice's data to each face using it
             //It may actually be possible to add this to the previous loop, but my reference didn't so I'm doing it in a separate loop for safety
@@ -481,30 +481,30 @@ namespace AquaModelLibrary.Core.General
                 var prmVert = prm.vertices[vertId];
 
                 var pos = prmVert.pos;
-                aiMesh.Vertices.Add(new Assimp.Vector3D(pos.X, pos.Y, pos.Z));
+                aiMesh.Vertices.Add(new Vector3(pos.X, pos.Y, pos.Z));
 
                 var nrm = prmVert.normal;
-                aiMesh.Normals.Add(new Assimp.Vector3D(nrm.X, nrm.Y, nrm.Z));
+                aiMesh.Normals.Add(new Vector3(nrm.X, nrm.Y, nrm.Z));
 
                 //Vert colors are bgra
                 var rawClr = prmVert.color;
-                var clr = new Assimp.Color4D(clrToFloat(rawClr[2]), clrToFloat(rawClr[1]), clrToFloat(rawClr[0]), clrToFloat(rawClr[3]));
+                var clr = new Vector4(clrToFloat(rawClr[2]), clrToFloat(rawClr[1]), clrToFloat(rawClr[0]), clrToFloat(rawClr[3]));
                 aiMesh.VertexColorChannels[0].Add(clr);
 
                 var uv1 = prmVert.uv1;
-                var aiUV1 = new Assimp.Vector3D(uv1.X, uv1.Y, 0f);
+                var aiUV1 = new Vector3(uv1.X, uv1.Y, 0f);
                 aiMesh.TextureCoordinateChannels[0].Add(aiUV1);
 
 
                 var uv2 = prmVert.uv2;
-                var aiUV2 = new Assimp.Vector3D(uv2.X, uv2.Y, 0f);
+                var aiUV2 = new Vector3(uv2.X, uv2.Y, 0f);
                 aiMesh.TextureCoordinateChannels[1].Add(aiUV2);
 
             }
 
             //Handle rigid meshes
             {
-                var aiBone = new Assimp.Bone();
+                var aiBone = new SharpAssimp.Bone();
                 var aqnBone = boneArray[0];
 
                 // Name
@@ -513,11 +513,11 @@ namespace AquaModelLibrary.Core.General
                 // VertexWeights
                 for (int i = 0; i < aiMesh.Vertices.Count; i++)
                 {
-                    var aiVertexWeight = new Assimp.VertexWeight(i, 1f);
+                    var aiVertexWeight = new SharpAssimp.VertexWeight(i, 1f);
                     aiBone.VertexWeights.Add(aiVertexWeight);
                 }
 
-                aiBone.OffsetMatrix = Assimp.Matrix4x4.Identity;
+                aiBone.OffsetMatrix = Matrix4x4.Identity;
 
                 aiMesh.Bones.Add(aiBone);
             }
@@ -525,16 +525,16 @@ namespace AquaModelLibrary.Core.General
             //Faces
             foreach (var face in prm.faces)
             {
-                aiMesh.Faces.Add(new Assimp.Face(new int[] { (int)face.X, (int)face.Y, (int)face.Z }));
+                aiMesh.Faces.Add(new SharpAssimp.Face(new int[] { (int)face.X, (int)face.Y, (int)face.Z }));
             }
 
             //Material
-            Assimp.Material mate = new Assimp.Material();
+            SharpAssimp.Material mate = new SharpAssimp.Material();
 
-            mate.ColorDiffuse = new Assimp.Color4D(1, 1, 1, 1);
+            mate.ColorDiffuse = new Vector4(1, 1, 1, 1);
             mate.Name = aiMeshName + "_material";
 
-            mate.ShadingMode = Assimp.ShadingMode.Phong;
+            mate.ShadingMode = SharpAssimp.ShadingMode.Phong;
 
             var meshNodeName = Path.GetFileNameWithoutExtension(filePath);
 
@@ -548,8 +548,8 @@ namespace AquaModelLibrary.Core.General
             aiMesh.MaterialIndex = aiScene.Materials.Count - 1;
 
             // Set up mesh node and add this mesh's index to it (This tells assimp to export it as a mesh for various formats)
-            var meshNode = new Assimp.Node(meshNodeName, aiScene.RootNode);
-            meshNode.Transform = Assimp.Matrix4x4.Identity;
+            var meshNode = new SharpAssimp.Node(meshNodeName, aiScene.RootNode);
+            meshNode.Transform = Matrix4x4.Identity;
 
             aiScene.RootNode.Children.Add(meshNode);
 
@@ -557,14 +557,6 @@ namespace AquaModelLibrary.Core.General
 
 
             return aiScene;
-        }
-
-        public static Assimp.Matrix4x4 GetAssimpMat4(Matrix4x4 mat4)
-        {
-            return new Assimp.Matrix4x4(mat4.M11, mat4.M21, mat4.M31, mat4.M41,
-                                        mat4.M12, mat4.M22, mat4.M32, mat4.M42,
-                                        mat4.M13, mat4.M23, mat4.M33, mat4.M43,
-                                        mat4.M14, mat4.M24, mat4.M34, mat4.M44);
         }
 
         public static float[] Vector4ToFloatArray(Vector4 vector4)
@@ -582,6 +574,60 @@ namespace AquaModelLibrary.Core.General
         {
             float flt = sht;
             return flt / 32767;
+        }
+
+        public static Matrix4x4 MatrixFromRotationX(float radians)
+        {
+            /*
+                 |  1  0       0       0 |
+             M = |  0  cos(A) -sin(A)  0 |
+                 |  0  sin(A)  cos(A)  0 |
+                 |  0  0       0       1 |	
+            */
+            Matrix4x4 m = Matrix4x4.Identity;
+            m.M22 = m.M33 = (float)Math.Cos(radians);
+            m.M32 = (float)Math.Sin(radians);
+            m.M23 = -m.M32;
+            return m;
+        }
+
+        public static Matrix4x4 MatrixFromRotationY(float radians)
+        {
+            /*
+                 |  cos(A)  0   sin(A)  0 |
+             M = |  0       1   0       0 |
+                 | -sin(A)  0   cos(A)  0 |
+                 |  0       0   0       1 |
+            */
+            Matrix4x4 m = Matrix4x4.Identity;
+            m.M11 = m.M33 = (float)Math.Cos(radians);
+            m.M13 = (float)Math.Sin(radians);
+            m.M31 = -m.M13;
+            return m;
+        }
+
+        public static Matrix4x4 MatrixFromRotationZ(float radians)
+        {
+            /*
+                 |  cos(A)  -sin(A)   0   0 |
+             M = |  sin(A)   cos(A)   0   0 |
+                 |  0        0        1   0 |
+                 |  0        0        0   1 |	
+            */
+            Matrix4x4 m = Matrix4x4.Identity;
+            m.M11 = m.M22 = (float)Math.Cos(radians);
+            m.M21 = (float)Math.Sin(radians);
+            m.M12 = -m.M21;
+            return m;
+        }
+
+        public static Matrix4x4 MatrixFromTranslation(Vector3 translation)
+        {
+            Matrix4x4 m = Matrix4x4.Identity;
+            m.M14 = translation.X;
+            m.M24 = translation.Y;
+            m.M34 = translation.Z;
+            return m;
         }
     }
 }

--- a/AquaModelLibrary.Core/General/AssimpModelExporter.cs
+++ b/AquaModelLibrary.Core/General/AssimpModelExporter.cs
@@ -338,7 +338,7 @@ namespace AquaModelLibrary.Core.General
                 }
 
                 //Faces
-                foreach (var face in aqp.strips[msh.vsetIndex].GetTriangles(true))
+                foreach (var face in aqp.strips[msh.psetIndex].GetTriangles(true))
                 {
                     aiMesh.Faces.Add(new SharpAssimp.Face(new int[] { (int)face.X, (int)face.Y, (int)face.Z }));
                 }

--- a/AquaModelLibrary.Core/General/AssimpModelExporter.cs
+++ b/AquaModelLibrary.Core/General/AssimpModelExporter.cs
@@ -71,12 +71,12 @@ namespace AquaModelLibrary.Core.General
 
                 //NODOs are a bit more primitive. We need to generate the matrix for these ones.
                 var matrix = Matrix4x4.Identity;
-                var rotation = MatrixFromRotationX(bn.eulRot.X) *
-                   MatrixFromRotationY(bn.eulRot.Y) *
-                   MatrixFromRotationZ(bn.eulRot.Z);
+                var rotation = Matrix4x4.CreateRotationX(bn.eulRot.X) *
+                   Matrix4x4.CreateRotationY(bn.eulRot.Y) *
+                   Matrix4x4.CreateRotationZ(bn.eulRot.Z);
 
                 matrix *= rotation;
-                matrix *= MatrixFromTranslation(new Vector3(bn.pos.X, bn.pos.Y, bn.pos.Z));
+                matrix *= Matrix4x4.CreateTranslation(new Vector3(bn.pos.X, bn.pos.Y, bn.pos.Z));
                 aiNode.Transform = matrix;
 
                 parentNodo.Children.Add(aiNode);
@@ -579,60 +579,6 @@ namespace AquaModelLibrary.Core.General
         {
             float flt = sht;
             return flt / 32767;
-        }
-
-        public static Matrix4x4 MatrixFromRotationX(float radians)
-        {
-            /*
-                 |  1  0       0       0 |
-             M = |  0  cos(A) -sin(A)  0 |
-                 |  0  sin(A)  cos(A)  0 |
-                 |  0  0       0       1 |	
-            */
-            Matrix4x4 m = Matrix4x4.Identity;
-            m.M22 = m.M33 = (float)Math.Cos(radians);
-            m.M32 = (float)Math.Sin(radians);
-            m.M23 = -m.M32;
-            return m;
-        }
-
-        public static Matrix4x4 MatrixFromRotationY(float radians)
-        {
-            /*
-                 |  cos(A)  0   sin(A)  0 |
-             M = |  0       1   0       0 |
-                 | -sin(A)  0   cos(A)  0 |
-                 |  0       0   0       1 |
-            */
-            Matrix4x4 m = Matrix4x4.Identity;
-            m.M11 = m.M33 = (float)Math.Cos(radians);
-            m.M13 = (float)Math.Sin(radians);
-            m.M31 = -m.M13;
-            return m;
-        }
-
-        public static Matrix4x4 MatrixFromRotationZ(float radians)
-        {
-            /*
-                 |  cos(A)  -sin(A)   0   0 |
-             M = |  sin(A)   cos(A)   0   0 |
-                 |  0        0        1   0 |
-                 |  0        0        0   1 |	
-            */
-            Matrix4x4 m = Matrix4x4.Identity;
-            m.M11 = m.M22 = (float)Math.Cos(radians);
-            m.M21 = (float)Math.Sin(radians);
-            m.M12 = -m.M21;
-            return m;
-        }
-
-        public static Matrix4x4 MatrixFromTranslation(Vector3 translation)
-        {
-            Matrix4x4 m = Matrix4x4.Identity;
-            m.M14 = translation.X;
-            m.M24 = translation.Y;
-            m.M34 = translation.Z;
-            return m;
         }
     }
 }

--- a/AquaModelLibrary.Core/General/AssimpModelImporter.cs
+++ b/AquaModelLibrary.Core/General/AssimpModelImporter.cs
@@ -21,28 +21,28 @@ namespace AquaModelLibrary.Core.General
         public static ScaleHandling scaleHandling = ScaleHandling.NoScaling;
         public static double customScale = 1;
 
-        public static Assimp.PostProcessSteps GetPostProcessSteps(bool preTransformVertices = false)
+        public static SharpAssimp.PostProcessSteps GetPostProcessSteps(bool preTransformVertices = false)
         {
-            Assimp.PostProcessSteps steps = Assimp.PostProcessSteps.Triangulate | Assimp.PostProcessSteps.JoinIdenticalVertices | Assimp.PostProcessSteps.FlipUVs;
+            SharpAssimp.PostProcessSteps steps = SharpAssimp.PostProcessSteps.Triangulate | SharpAssimp.PostProcessSteps.JoinIdenticalVertices | SharpAssimp.PostProcessSteps.FlipUVs;
 
             if(preTransformVertices)
             {
-                steps |=  Assimp.PostProcessSteps.PreTransformVertices;
+                steps |=  SharpAssimp.PostProcessSteps.PreTransformVertices;
             }
 
             if(scaleHandling == ScaleHandling.FileScaling)
             {
-                steps |= Assimp.PostProcessSteps.GlobalScale;
+                steps |= SharpAssimp.PostProcessSteps.GlobalScale;
             }
 
             return steps;
         }
 
-        public static Assimp.Scene GetAssimpScene(string path, Assimp.PostProcessSteps pps)
+        public static SharpAssimp.Scene GetAssimpScene(string path, SharpAssimp.PostProcessSteps pps)
         {
-            Assimp.AssimpContext context = new Assimp.AssimpContext();
-            context.SetConfig(new Assimp.Configs.FBXPreservePivotsConfig(true));
-            Assimp.Scene aiScene = context.ImportFile(path, pps);
+            SharpAssimp.AssimpContext context = new SharpAssimp.AssimpContext();
+            context.SetConfig(new SharpAssimp.Configs.FBXPreservePivotsConfig(true));
+            SharpAssimp.Scene aiScene = context.ImportFile(path, pps);
 
             return aiScene;
         }
@@ -67,10 +67,10 @@ namespace AquaModelLibrary.Core.General
 
         public static List<(string fileName, AquaMotion aqm)> AssimpAQMConvert(string initialFilePath, bool forceNoPlayerExport, bool useScaleFrames)
         {
-            Assimp.AssimpContext context = new Assimp.AssimpContext();
-            context.SetConfig(new Assimp.Configs.FBXPreservePivotsConfig(false));
+            SharpAssimp.AssimpContext context = new SharpAssimp.AssimpContext();
+            context.SetConfig(new SharpAssimp.Configs.FBXPreservePivotsConfig(false));
             
-            Assimp.Scene aiScene = context.ImportFile(initialFilePath, GetPostProcessSteps(false));
+            SharpAssimp.Scene aiScene = context.ImportFile(initialFilePath, GetPostProcessSteps(false));
 
             double baseScale = SetAssimpScale(aiScene);
 
@@ -82,7 +82,7 @@ namespace AquaModelLibrary.Core.General
             string inputFilename = Path.GetFileNameWithoutExtension(initialFilePath);
             List<string> aqmNames = new List<string>(); //Leave off extensions in case we want this to be .trm later
             List<(string fileName, AquaMotion aqm)> aqmList = new List<(string fileName, AquaMotion aqm)>();
-            Dictionary<int, Assimp.Node> aiNodes = GetAnimatedNodes(aiScene);
+            Dictionary<int, SharpAssimp.Node> aiNodes = GetAnimatedNodes(aiScene);
             var nodeKeys = aiNodes.Keys.ToList();
             nodeKeys.Sort();
             if(nodeKeys.Count == 0)
@@ -497,7 +497,7 @@ namespace AquaModelLibrary.Core.General
             WriteMotions(initialFilePath, AssimpAQMConvert(initialFilePath, forceNoPlayerExport, useScaleFrames));
         }
 
-        private static void AddOneScaleFrame(bool useScaleFrames, KeyData node, bool add0x80 = false, Assimp.Node aiNode = null)
+        private static void AddOneScaleFrame(bool useScaleFrames, KeyData node, bool add0x80 = false, SharpAssimp.Node aiNode = null)
         {
             if (useScaleFrames)
             {
@@ -511,7 +511,7 @@ namespace AquaModelLibrary.Core.General
                 }
                 else
                 {
-                    Matrix4x4.Invert(GetMat4FromAssimpMat4(aiNode.Transform), out Matrix4x4 mat4);
+                    Matrix4x4.Invert(aiNode.Transform, out Matrix4x4 mat4);
                     if (float.IsNaN(mat4.M11))
                     {
                         mat4.M11 = 1.0f;
@@ -530,25 +530,25 @@ namespace AquaModelLibrary.Core.General
             }
         }
 
-        private static void AddOneRotFrame(KeyData node, Assimp.Node aiNode, bool add0x80 = false)
+        private static void AddOneRotFrame(KeyData node, SharpAssimp.Node aiNode, bool add0x80 = false)
         {
             MKEY rotKeys = new MKEY();
             rotKeys.keyType = 2;
             rotKeys.dataType = 3;
             rotKeys.keyCount = 1;
-            Matrix4x4.Invert(GetMat4FromAssimpMat4(aiNode.Transform), out Matrix4x4 mat4);
+            Matrix4x4.Invert(aiNode.Transform, out Matrix4x4 mat4);
             var quat = Quaternion.CreateFromRotationMatrix(mat4);
             rotKeys.vector4Keys = new List<Vector4>() { new Vector4(quat.X, quat.Y, quat.Z, quat.W) };
             node.keyData.Add(rotKeys);
         }
 
-        private static void AddOnePosFrame(KeyData node, Assimp.Node aiNode, double baseScale, bool add0x80 = false)
+        private static void AddOnePosFrame(KeyData node, SharpAssimp.Node aiNode, double baseScale, bool add0x80 = false)
         {
             MKEY posKeys = new MKEY();
             posKeys.keyType = 1;
             posKeys.dataType = 1;
             posKeys.keyCount = 1;
-            var mat4 = GetMat4FromAssimpMat4(aiNode.Transform);
+            var mat4 = aiNode.Transform;
             posKeys.vector4Keys = new List<Vector4>() { new Vector4((float)(mat4.M14 * baseScale), (float)(mat4.M24 * baseScale), (float)(mat4.M34 * baseScale), 0) };
             node.keyData.Add(posKeys);
         }
@@ -577,9 +577,9 @@ namespace AquaModelLibrary.Core.General
             }
         }
 
-        private static Dictionary<int, Assimp.Node> GetAnimatedNodes(Assimp.Scene aiScene)
+        private static Dictionary<int, SharpAssimp.Node> GetAnimatedNodes(SharpAssimp.Scene aiScene)
         {
-            Dictionary<int, Assimp.Node> nodes = new Dictionary<int, Assimp.Node>();
+            Dictionary<int, SharpAssimp.Node> nodes = new Dictionary<int, SharpAssimp.Node>();
 
             foreach (var node in aiScene.RootNode.Children)
             {
@@ -589,7 +589,7 @@ namespace AquaModelLibrary.Core.General
             return nodes;
         }
 
-        private static void CollectAnimated(Assimp.Node node, Dictionary<int, Assimp.Node> nodes)
+        private static void CollectAnimated(SharpAssimp.Node node, Dictionary<int, SharpAssimp.Node> nodes)
         {
             //Be extra sure that this isn't an effect node
             if (IsAnimatedNode(node, out string name, out int num))
@@ -605,14 +605,14 @@ namespace AquaModelLibrary.Core.General
         }
 
         //Check if a node is an animated by node by checking if it has the numbering formatting and is NOT marked as an effect node. Output name 
-        private static bool IsAnimatedNode(Assimp.Node node, out string name, out int num)
+        private static bool IsAnimatedNode(SharpAssimp.Node node, out string name, out int num)
         {
             bool isNumbered = IsNumberedAnimated(node, out name, out num);
             return isNumbered && !node.Name.Contains("#Eff");
         }
 
         //Check if node is numbered as an animated node. Output name
-        private static bool IsNumberedAnimated(Assimp.Node node, out string name, out int num)
+        private static bool IsNumberedAnimated(SharpAssimp.Node node, out string name, out int num)
         {
             name = node.Name;
             num = -1;
@@ -631,11 +631,11 @@ namespace AquaModelLibrary.Core.General
 
         public static void AssimpPRMConvert(string initialFilePath, string finalFilePath)
         {
-            Assimp.AssimpContext context = new Assimp.AssimpContext();
-            context.SetConfig(new Assimp.Configs.FBXPreservePivotsConfig(true));
+            SharpAssimp.AssimpContext context = new SharpAssimp.AssimpContext();
+            context.SetConfig(new SharpAssimp.Configs.FBXPreservePivotsConfig(true));
             var postProcessSteps = GetPostProcessSteps(true);
 
-            Assimp.Scene aiScene = context.ImportFile(initialFilePath, postProcessSteps);
+            SharpAssimp.Scene aiScene = context.ImportFile(initialFilePath, postProcessSteps);
             double baseScale = SetAssimpScale(aiScene);
 
             PRM prm = new PRM();
@@ -643,7 +643,7 @@ namespace AquaModelLibrary.Core.General
             int totalVerts = 0;
 
             //Iterate through and combine meshes. PRMs can only have a single mesh
-            var parentMatrix = Matrix4x4.Transpose(GetMat4FromAssimpMat4(aiScene.RootNode.Transform));
+            var parentMatrix = Matrix4x4.Transpose(aiScene.RootNode.Transform);
             parentMatrix.M41 = (float)(parentMatrix.M41 * baseScale);
             parentMatrix.M42 = (float)(parentMatrix.M42 * baseScale);
             parentMatrix.M43 = (float)(parentMatrix.M43 * baseScale);
@@ -651,9 +651,9 @@ namespace AquaModelLibrary.Core.General
             File.WriteAllBytes(finalFilePath, prm.GetBytes(4));
         }
 
-        private static void IterateAiNodesPRM(PRM prm, ref int totalVerts, Assimp.Scene aiScene, Assimp.Node node, Matrix4x4 parentTfm, double baseScale)
+        private static void IterateAiNodesPRM(PRM prm, ref int totalVerts, SharpAssimp.Scene aiScene, SharpAssimp.Node node, Matrix4x4 parentTfm, double baseScale)
         {
-            Matrix4x4 nodeMat = Matrix4x4.Transpose(GetMat4FromAssimpMat4(node.Transform));
+            Matrix4x4 nodeMat = Matrix4x4.Transpose(node.Transform);
             nodeMat.M41 = (float)(nodeMat.M41 * baseScale);
             nodeMat.M42 = (float)(nodeMat.M42 * baseScale);
             nodeMat.M43 = (float)(nodeMat.M43 * baseScale);
@@ -671,7 +671,7 @@ namespace AquaModelLibrary.Core.General
             }
         }
 
-        private static void AddAiMeshToPRM(PRM prm, ref int totalVerts, Assimp.Mesh aiMesh, Matrix4x4 nodeMat, double baseScale)
+        private static void AddAiMeshToPRM(PRM prm, ref int totalVerts, SharpAssimp.Mesh aiMesh, Matrix4x4 nodeMat, double baseScale)
         {
             //Convert vertices
             for (int vertId = 0; vertId < aiMesh.VertexCount; vertId++)
@@ -684,7 +684,7 @@ namespace AquaModelLibrary.Core.General
                 if (aiMesh.HasVertexColors(0))
                 {
                     var aiColor = aiMesh.VertexColorChannels[0][vertId];
-                    vert.color = new byte[] { (byte)(aiColor.B * 255), (byte)(aiColor.G * 255), (byte)(aiColor.R * 255), (byte)(aiColor.A * 255) };
+                    vert.color = new byte[] { (byte)(aiColor.Z * 255), (byte)(aiColor.Y * 255), (byte)(aiColor.X * 255), (byte)(aiColor.W * 255) };
                 }
                 else
                 {
@@ -742,11 +742,11 @@ namespace AquaModelLibrary.Core.General
             {
                 preTransformVerts = true;
             }
-            Assimp.AssimpContext context = new Assimp.AssimpContext();
-            context.SetConfig(new Assimp.Configs.FBXPreservePivotsConfig(preserveFBXPivots));
+            SharpAssimp.AssimpContext context = new SharpAssimp.AssimpContext();
+            context.SetConfig(new SharpAssimp.Configs.FBXPreservePivotsConfig(preserveFBXPivots));
             var postProcessSteps = GetPostProcessSteps(preTransformVerts);
 
-            Assimp.Scene aiScene = context.ImportFile(initialFilePath, postProcessSteps);
+            SharpAssimp.Scene aiScene = context.ImportFile(initialFilePath, postProcessSteps);
             double baseScale = SetAssimpScale(aiScene);
 
             AquaObject aqp = new AquaObject();
@@ -807,7 +807,7 @@ namespace AquaModelLibrary.Core.General
             CheckForNameNodeNumbers(aiScene.RootNode, ref useNameNodeNum);
             BuildAiNodeDictionary(aiScene.RootNode, ref nodeCounter, boneDict, useNameNodeNum);
 
-            var parentMatrix = Matrix4x4.Transpose(GetMat4FromAssimpMat4(aiScene.RootNode.Transform));
+            var parentMatrix = Matrix4x4.Transpose(aiScene.RootNode.Transform);
             parentMatrix.M41 = (float)(parentMatrix.M41 * baseScale);
             parentMatrix.M42 = (float)(parentMatrix.M42 * baseScale);
             parentMatrix.M43 = (float)(parentMatrix.M43 * baseScale);
@@ -833,7 +833,7 @@ namespace AquaModelLibrary.Core.General
             return aqp;
         }
 
-        public static double SetAssimpScale(Assimp.Scene aiScene)
+        public static double SetAssimpScale(SharpAssimp.Scene aiScene)
         { 
             double baseScale = 1;
             switch (scaleHandling)
@@ -852,7 +852,7 @@ namespace AquaModelLibrary.Core.General
             return baseScale;
         }
 
-        private static Assimp.Node GetRootNode(Assimp.Node aiNode)
+        private static SharpAssimp.Node GetRootNode(SharpAssimp.Node aiNode)
         {
             var nodeCountName = GetNodeNumber(aiNode.Name);
             if (nodeCountName == 0)
@@ -870,7 +870,7 @@ namespace AquaModelLibrary.Core.General
             return null;
         }
 
-        private static void BuildAiNodeDictionary(Assimp.Node aiNode, ref int nodeCounter, Dictionary<string, int> boneDict, bool useNameNodeNum)
+        private static void BuildAiNodeDictionary(SharpAssimp.Node aiNode, ref int nodeCounter, Dictionary<string, int> boneDict, bool useNameNodeNum)
         {
             var nodeCountName = GetNodeNumber(aiNode.Name);
             if (nodeCountName != -1)
@@ -895,7 +895,7 @@ namespace AquaModelLibrary.Core.General
             }
         }
 
-        private static void CheckForNameNodeNumbers(Assimp.Node aiNode, ref bool useNameNodeNum)
+        private static void CheckForNameNodeNumbers(SharpAssimp.Node aiNode, ref bool useNameNodeNum)
         {
             var nodeCountName = GetNodeNumber(aiNode.Name);
             if (nodeCountName != -1)
@@ -914,7 +914,7 @@ namespace AquaModelLibrary.Core.General
             }
         }
 
-        private static void IterateAiNodesAQP(AquaObject aqp, AquaNode aqn, Assimp.Scene aiScene, Assimp.Node aiNode, Matrix4x4 parentTfm, double baseScale, Dictionary<string, int> boneDict)
+        private static void IterateAiNodesAQP(AquaObject aqp, AquaNode aqn, SharpAssimp.Scene aiScene, SharpAssimp.Node aiNode, Matrix4x4 parentTfm, double baseScale, Dictionary<string, int> boneDict)
         {
             //Decide if this is an effect node or not
             string nodeName = aiNode.Name;
@@ -981,7 +981,7 @@ namespace AquaModelLibrary.Core.General
 
                 //Assign transform data
                 Matrix4x4 worldMat;
-                var localMat = SwapRow4Column4Mat4(GetMat4FromAssimpMat4(aiNode.Transform));
+                var localMat = SwapRow4Column4Mat4(aiNode.Transform);
                 Matrix4x4.Decompose(localMat, out var scale, out var rot, out var pos);
 
                 worldMat = localMat;
@@ -1032,7 +1032,7 @@ namespace AquaModelLibrary.Core.General
                     ParseShorts(nodeName, out nodo.boneShort1, out nodo.boneShort2);
 
                     //Assign transform data
-                    var localMat = SwapRow4Column4Mat4(GetMat4FromAssimpMat4(aiNode.Transform));
+                    var localMat = SwapRow4Column4Mat4(aiNode.Transform);
                     nodo.pos = localMat.Translation;
 
                     nodo.eulRot = MathExtras.QuaternionToEuler(Quaternion.CreateFromRotationMatrix(localMat));
@@ -1045,7 +1045,7 @@ namespace AquaModelLibrary.Core.General
                 }
             }
 
-            Matrix4x4 nodeMat = Matrix4x4.Transpose(GetMat4FromAssimpMat4(aiNode.Transform));
+            Matrix4x4 nodeMat = Matrix4x4.Transpose(aiNode.Transform);
             nodeMat.M41 *= (float)(nodeMat.M41 * baseScale);
             nodeMat.M42 *= (float)(nodeMat.M42 * baseScale);
             nodeMat.M43 *= (float)(nodeMat.M43 * baseScale);
@@ -1063,7 +1063,7 @@ namespace AquaModelLibrary.Core.General
             }
         }
 
-        private static void AddAiMeshToAQP(AquaObject aqp, Assimp.Mesh mesh, Matrix4x4 nodeMat, double baseScale, Dictionary<string, int> boneDict)
+        private static void AddAiMeshToAQP(AquaObject aqp, SharpAssimp.Mesh mesh, Matrix4x4 nodeMat, double baseScale, Dictionary<string, int> boneDict)
         {
             GenericTriangles genTris = new GenericTriangles();
             genTris.name = mesh.Name;
@@ -1104,7 +1104,7 @@ namespace AquaModelLibrary.Core.General
                     if (mesh.HasVertexColors(0))
                     {
                         var color = mesh.VertexColorChannels[0][v];
-                        faceVtxl.vertColors.Add(new byte[] { floatToColor(color.B), floatToColor(color.G), floatToColor(color.R), floatToColor(color.A) });
+                        faceVtxl.vertColors.Add(new byte[] { floatToColor(color.Z), floatToColor(color.Y), floatToColor(color.X), floatToColor(color.W) });
                     }
                     if (mesh.HasTextureCoords(0))
                     {
@@ -1268,33 +1268,17 @@ namespace AquaModelLibrary.Core.General
                 return false;
             }
         }
-        private static Matrix4x4 GetWorldTransform(Assimp.Node aiNode)
+        private static Matrix4x4 GetWorldTransform(SharpAssimp.Node aiNode)
         {
             var transform = aiNode.Transform;
 
             while ((aiNode = aiNode.Parent) != null)
                 transform *= aiNode.Transform;
 
-            return ToNumericsTransposed(transform);
-        }
-
-        private static Matrix4x4 ToNumericsTransposed(Assimp.Matrix4x4 value)
-        {
-            return new Matrix4x4(
-                value.A1, value.B1, value.C1, value.D1,
-                value.A2, value.B2, value.C2, value.D2,
-                value.A3, value.B3, value.C3, value.D3,
-                value.A4, value.B4, value.C4, value.D4);
+            return Matrix4x4.Transpose(transform);
         }
 
 
-        private static Matrix4x4 GetMat4FromAssimpMat4(Assimp.Matrix4x4 mat4)
-        {
-            return new Matrix4x4(mat4.A1, mat4.A2, mat4.A3, mat4.A4,
-                                 mat4.B1, mat4.B2, mat4.B3, mat4.B4,
-                                 mat4.C1, mat4.C2, mat4.C3, mat4.C4,
-                                 mat4.D1, mat4.D2, mat4.D3, mat4.D4);
-        }
         private static Matrix4x4 SwapRow4Column4Mat4(Matrix4x4 mat4)
         {
             return new Matrix4x4(mat4.M11, mat4.M12, mat4.M13, mat4.M41,

--- a/AquaModelLibrary.Core/General/AssimpModelImporter.cs
+++ b/AquaModelLibrary.Core/General/AssimpModelImporter.cs
@@ -1273,7 +1273,7 @@ namespace AquaModelLibrary.Core.General
             var transform = aiNode.Transform;
 
             while ((aiNode = aiNode.Parent) != null)
-                transform *= aiNode.Transform;
+                transform = aiNode.Transform * transform;
 
             return Matrix4x4.Transpose(transform);
         }


### PR DESCRIPTION
Switched the assimp dependency to https://github.com/JeremyAnsel/SharpAssimp, since that is actively maintained.

Fixed a few issues I ran into while using the assimp export on various models:

- The various material texture properties (`TextureNormal` etc.) will ignore any texture that isn't slot 0, so only the diffuse texture was getting exported.
- Fixed face export using the wrong set of faces on some models. Updated to match the FBX export code.
- Fixed vertex weight export reading out of bounds when exporting a model without the right skeleton. Updated to match the FBX export code and assign out of bounds values to bone 0.